### PR TITLE
update for AWS version 4

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ module "db_instance" {
   kms_key_id        = var.kms_key_id
   license_model     = var.license_model
 
-  name                                = var.name
+  db_name                                = var.db_name
   username                            = var.username
   password                            = local.master_password
   port                                = var.port

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ module "db_instance" {
   kms_key_id        = var.kms_key_id
   license_model     = var.license_model
 
-  db_name                                = var.db_name
+  db_name                             = var.db_name
   username                            = var.username
   password                            = local.master_password
   port                                = var.port

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -2,6 +2,12 @@ locals {
   is_mssql = element(split("-", var.engine), 0) == "sqlserver"
 
   monitoring_role_arn = var.create_monitoring_role ? aws_iam_role.enhanced_monitoring[0].arn : var.monitoring_role_arn
+  
+  # Replicas will use source metadata in hashicorp aws 4+
+  username       = var.replicate_source_db != null ? null : var.username
+  password       = var.replicate_source_db != null ? null : var.password
+  engine         = var.replicate_source_db != null ? null : var.engine
+  engine_version = var.replicate_source_db != null ? null : var.engine_version
 }
 
 # Ref. https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces
@@ -112,8 +118,8 @@ resource "aws_db_instance" "this_mssql" {
 
   identifier = var.identifier
 
-  engine            = var.engine
-  engine_version    = var.engine_version
+  engine            = local.engine
+  engine_version    = local.engine_version
   instance_class    = var.instance_class
   allocated_storage = var.allocated_storage
   storage_type      = var.storage_type
@@ -121,9 +127,9 @@ resource "aws_db_instance" "this_mssql" {
   kms_key_id        = var.kms_key_id
   license_model     = var.license_model
 
-  name                                = var.name
-  username                            = var.username
-  password                            = var.password
+  db_name                             = var.name
+  username                            = local.username
+  password                            = local.password
   port                                = var.port
   domain                              = var.domain
   domain_iam_role_name                = var.domain_iam_role_name

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -28,8 +28,8 @@ resource "aws_db_instance" "this" {
 
   identifier = var.identifier
 
-  engine            = var.engine
-  engine_version    = var.engine_version
+  engine            = local.engine
+  engine_version    = local.engine_version
   instance_class    = var.instance_class
   allocated_storage = var.allocated_storage
   storage_type      = var.storage_type
@@ -37,9 +37,9 @@ resource "aws_db_instance" "this" {
   kms_key_id        = var.kms_key_id
   license_model     = var.license_model
 
-  name                                = var.name
-  username                            = var.username
-  password                            = var.password
+  db_name                             = var.name
+  username                            = local.username
+  password                            = local.password
   port                                = var.port
   domain                              = var.domain
   domain_iam_role_name                = var.domain_iam_role_name

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -127,7 +127,7 @@ resource "aws_db_instance" "this_mssql" {
   kms_key_id        = var.kms_key_id
   license_model     = var.license_model
 
-  db_name                             = var.name
+  db_name                             = var.db_name
   username                            = local.username
   password                            = local.password
   port                                = var.port

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -37,7 +37,7 @@ resource "aws_db_instance" "this" {
   kms_key_id        = var.kms_key_id
   license_model     = var.license_model
 
-  db_name                             = var.name
+  db_name                             = var.db_name
   username                            = local.username
   password                            = local.password
   port                                = var.port

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -77,7 +77,7 @@ variable "instance_class" {
   type        = string
 }
 
-variable "name" {
+variable "db_name" {
   description = "The DB name to create. If omitted, no database is created initially"
   type        = string
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable "instance_class" {
   type        = string
 }
 
-variable "name" {
+variable "db_name" {
   description = "The DB name to create. If omitted, no database is created initially"
   type        = string
   default     = null


### PR DESCRIPTION
Most of these changes I got from updates made from upstream. Name as a variable no longer works, and db_name is supposed to be left null for replicas. Leaving db_name null is something we will code into our own Terraform codebase instead of this package.