### PR TITLE
FED-15439: In a cluster upgrade, you can't null a version number

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -6,8 +6,8 @@ locals {
   # Replicas will use source metadata in hashicorp aws 4+
   username       = var.replicate_source_db != null ? null : var.username
   password       = var.replicate_source_db != null ? null : var.password
-  engine         = var.replicate_source_db != null ? null : var.engine
-  engine_version = var.replicate_source_db != null ? null : var.engine_version
+  engine         = var.engine
+  engine_version = var.engine_version
 }
 
 # Ref. https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces


### PR DESCRIPTION
To update a version number used with a postgres cluster, we need to also update the version number of each replica instance.
